### PR TITLE
Render compatible with llvm 4.0.0

### DIFF
--- a/src/backend/llvm_ast.c
+++ b/src/backend/llvm_ast.c
@@ -401,7 +401,7 @@ struct LLVMOpaqueModule *blvm_create_module(
         // LLVMLinkeModules2() destroys the source module so we need to clone
         LLVMModuleRef clone_of_link =  LLVMCloneModule(link_source);
         // if an error occurs LLVMLinkModules() returns true ...
-#if RF_LLVM_VERSION_MAJOR >= 3 && RF_LLVM_VERSION_MINOR >= 8
+#if (RF_LLVM_VERSION_MAJOR == 3 && RF_LLVM_VERSION_MINOR >= 8) || RF_LLVM_VERSION_MAJOR >= 4
         if (true == LLVMLinkModules2(ctx->llvm_mod, clone_of_link)) {
 #else
         if (true == LLVMLinkModules(ctx->llvm_mod, clone_of_link, LLVMLinkerDestroySource, 0)) {

--- a/src/backend/llvm_globals.c
+++ b/src/backend/llvm_globals.c
@@ -156,8 +156,13 @@ static void bllvm_create_global_donothing_decl(struct llvm_traversal_ctx *ctx)
         ctx->llvm_mod,
         "llvm.donothing",
         LLVMFunctionType(LLVMVoidTypeInContext(ctx->llvm_context), NULL, 0, false));
+#if (RF_LLVM_VERSION_MAJOR == 3 && RF_LLVM_VERSION_MINOR > 7) || RF_LLVM_VERSION_MAJOR >= 4
     LLVMAddAttributeAtIndex(fn, -1, bllvm_create_enumattr_or_die(ctx->llvm_context, "nounwind"));
     LLVMAddAttributeAtIndex(fn, -1, bllvm_create_enumattr_or_die(ctx->llvm_context, "readnone"));
+#else
+    LLVMAddFunctionAttr(fn, LLVMNoUnwindAttribute);
+    LLVMAddFunctionAttr(fn, LLVMReadNoneAttribute);
+#endif
 }
 
 bool bllvm_create_global_functions(struct llvm_traversal_ctx *ctx)

--- a/src/backend/llvm_globals.c
+++ b/src/backend/llvm_globals.c
@@ -142,7 +142,7 @@ static void bllvm_create_global_memcpy_decl(struct llvm_traversal_ctx *ctx)
         LLVMInt32TypeInContext(ctx->llvm_context),
         LLVMInt1TypeInContext(ctx->llvm_context)
     };
-    LLVMValueRef fn =  LLVMAddFunction(
+    LLVMAddFunction(
         ctx->llvm_mod,
         "llvm.memcpy.p0i8.p0i8.i64",
         LLVMFunctionType(LLVMVoidTypeInContext(ctx->llvm_context), args, 5, false)
@@ -156,8 +156,8 @@ static void bllvm_create_global_donothing_decl(struct llvm_traversal_ctx *ctx)
         ctx->llvm_mod,
         "llvm.donothing",
         LLVMFunctionType(LLVMVoidTypeInContext(ctx->llvm_context), NULL, 0, false));
-    LLVMAddFunctionAttr(fn, LLVMNoUnwindAttribute);
-    LLVMAddFunctionAttr(fn, LLVMReadNoneAttribute);
+    LLVMAddAttributeAtIndex(fn, -1, bllvm_create_enumattr_or_die(ctx->llvm_context, "nounwind"));
+    LLVMAddAttributeAtIndex(fn, -1, bllvm_create_enumattr_or_die(ctx->llvm_context, "readnone"));
 }
 
 bool bllvm_create_global_functions(struct llvm_traversal_ctx *ctx)

--- a/src/backend/llvm_globals.c
+++ b/src/backend/llvm_globals.c
@@ -147,13 +147,6 @@ static void bllvm_create_global_memcpy_decl(struct llvm_traversal_ctx *ctx)
         "llvm.memcpy.p0i8.p0i8.i64",
         LLVMFunctionType(LLVMVoidTypeInContext(ctx->llvm_context), args, 5, false)
     );
-
-    // adding attributes to the arguments of memcpy as seen when generating llvm code via clang
-    //@llvm.memcpy(i8* nocapture, i8* nocapture readonly, i64, i32, i1)
-    // TODO: Not sure if these attributes would always work correctly here.
-    LLVMAddAttribute(LLVMGetParam(fn, 0), LLVMNoCaptureAttribute);
-    LLVMAddAttribute(LLVMGetParam(fn, 1), LLVMNoCaptureAttribute);
-    LLVMAddAttribute(LLVMGetParam(fn, 1), LLVMReadOnlyAttribute);
 }
 
 static void bllvm_create_global_donothing_decl(struct llvm_traversal_ctx *ctx)

--- a/src/backend/llvm_utils.c
+++ b/src/backend/llvm_utils.c
@@ -250,3 +250,6 @@ unsigned long long bllvm_type_storagesize(
         ? 0
         : LLVMStoreSizeOfType(tdata, type);
 }
+
+i_INLINE_INS unsigned bllvm_get_enumattr_kind_id_or_die(const char *name);
+i_INLINE_INS LLVMAttributeRef bllvm_create_enumattr_or_die(LLVMContextRef ctx, const char *name);

--- a/src/backend/llvm_utils.c
+++ b/src/backend/llvm_utils.c
@@ -251,5 +251,7 @@ unsigned long long bllvm_type_storagesize(
         : LLVMStoreSizeOfType(tdata, type);
 }
 
+#if (RF_LLVM_VERSION_MAJOR == 3 && RF_LLVM_VERSION_MINOR > 7) || RF_LLVM_VERSION_MAJOR >= 4
 i_INLINE_INS unsigned bllvm_get_enumattr_kind_id_or_die(const char *name);
 i_INLINE_INS LLVMAttributeRef bllvm_create_enumattr_or_die(LLVMContextRef ctx, const char *name);
+#endif

--- a/src/backend/llvm_utils.h
+++ b/src/backend/llvm_utils.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#if (RF_LLVM_VERSION_MAJOR >= 3 && RF_LLVM_VERSION_MINOR > 7)
+#if RF_LLVM_VERSION_MAJOR >= 3 && RF_LLVM_VERSION_MINOR > 7
 #include <llvm-c/Types.h>
 #endif
 #include <llvm-c/Core.h>
@@ -146,7 +146,7 @@ unsigned long long  bllvm_type_storagesize(
     struct llvm_traversal_ctx *ctx
 );
 
-
+#if (RF_LLVM_VERSION_MAJOR == 3 && RF_LLVM_VERSION_MINOR > 7) || RF_LLVM_VERSION_MAJOR >= 4
 i_INLINE_DECL unsigned bllvm_get_enumattr_kind_id_or_die(const char *name)
 {
     unsigned len = strlen(name);
@@ -159,4 +159,6 @@ i_INLINE_DECL LLVMAttributeRef bllvm_create_enumattr_or_die(LLVMContextRef ctx, 
 {
     return LLVMCreateEnumAttribute(ctx, bllvm_get_enumattr_kind_id_or_die(name), 0);
 }
+#endif
+
 #endif

--- a/src/backend/llvm_utils.h
+++ b/src/backend/llvm_utils.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include <string.h>
+#if (RF_LLVM_VERSION_MAJOR >= 3 && RF_LLVM_VERSION_MINOR > 7)
 #include <llvm-c/Types.h>
+#endif
 #include <llvm-c/Core.h>
 #include <rfbase/defs/inline.h>
 #include <rfbase/utils/sanity.h>

--- a/src/backend/llvm_utils.h
+++ b/src/backend/llvm_utils.h
@@ -2,6 +2,11 @@
 #define LFR_BACKEND_LLVM_UTILS_H
 
 #include <stdint.h>
+#include <string.h>
+#include <llvm-c/Types.h>
+#include <llvm-c/Core.h>
+#include <rfbase/defs/inline.h>
+#include <rfbase/utils/sanity.h>
 
 struct LLVMOpaqueModule;
 struct LLVMOpaqueBasicBlock;
@@ -138,4 +143,18 @@ unsigned long long  bllvm_type_storagesize(
     struct LLVMOpaqueType *type,
     struct llvm_traversal_ctx *ctx
 );
+
+
+i_INLINE_DECL unsigned bllvm_get_enumattr_kind_id_or_die(const char *name)
+{
+    unsigned len = strlen(name);
+    unsigned id = LLVMGetEnumAttributeKindForName(name, len);
+    RF_ASSERT(id != 0, "Failed to find Enum Attribute for %.*s", len, name);
+    return id;
+}
+
+i_INLINE_DECL LLVMAttributeRef bllvm_create_enumattr_or_die(LLVMContextRef ctx, const char *name)
+{
+    return LLVMCreateEnumAttribute(ctx, bllvm_get_enumattr_kind_id_or_die(name), 0);
+}
 #endif


### PR DESCRIPTION
- There was an error with the #ifdef LLVM Version check

- In the [LLVM 4.0.0 changelog](http://releases.llvm.org/4.0.0/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release) we can see that `LLVMAddAttribute()` has been removed. The new way to handle attributes is a bit more complicated and some utility functions
  were added to the codebase under `llmv_utils.h` to allow for this. They are modeled in the same way mesa does it in their [AMD drivers](https://github.com/mesa3d/mesa/blob/7372e3cf5f2df9dd2ec0423a4425baad098bf326/src/amd/common/ac_llvm_util.c#L195). 

- Remove attributes from memcpy inside of `llvm_globals.c` as they were not needed.

- Adjusted the arguments to `donothing()` to use the new scheme