### PR TITLE
extend the Travis CI Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,53 @@
 
 language: c
 sudo: required
+
+os: linux
 dist: trusty
+
 services:
   - docker
 compiler:
   - gcc
-os:
-  - linux
-  - osx
 
+
+# test multiple distros, CPU Architectures and OS's
+jobs:
+  include:
+    # trusty
+    - os: linux
+      dist: trusty
+      arch: amd64
+
+    # xenial
+    - os: linux
+      dist: xenial
+      arch: amd64
+
+    - os: linux
+      dist: xenial
+      arch: arm64
+
+    # bionic
+    - os: linux
+      dist: bionic
+      arch: amd64
+
+    - os: linux
+      dist: bionic
+      arch: arm64
+
+    # focal
+    - os: linux
+      dist: focal
+      arch: amd64
+
+    - os: linux
+      dist: focal
+      arch: arm64
+
+    # macOS
+    - os: osx
 
 before_install:
   - ./.travis/install.sh


### PR DESCRIPTION
Hello,

i noticed your repo has many issues but has not been maintained in a long time.

So i wanted to make a PR in the Hacktoberfest spirit.

If this gets merged, please add the "hacktoberfest-accepted" tag.

I would have extended the build matrix more for macOS but i never build on that, 
so i don't know what would be appropriate.

Cheers!